### PR TITLE
Fix incorrect UnixTime conversion.

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.2.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.100
     - name: Build with dotnet

--- a/src/BookmarksManager/ExtensionMethods/DateTimeHelper.cs
+++ b/src/BookmarksManager/ExtensionMethods/DateTimeHelper.cs
@@ -4,10 +4,9 @@ namespace BookmarksManager
 {
     public static class DateTimeHelper
     {
-        public static int ToUnixTimestamp(this DateTime time)
+        public static long ToUnixTimestamp(this DateTime time)
         {
-            //todo: use DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-            return (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc))).TotalSeconds;
+            return (long)((DateTimeOffset)time).ToUnixTimeSeconds();
         }
 
         public static DateTime? FromUnixTimeStamp(long? unixTimeStamp)

--- a/src/BookmarksManager/ExtensionMethods/DateTimeHelper.cs
+++ b/src/BookmarksManager/ExtensionMethods/DateTimeHelper.cs
@@ -14,7 +14,7 @@ namespace BookmarksManager
             if (!unixTimeStamp.HasValue || unixTimeStamp < 1)
                 return null;
             unixTimeStamp = takeNDigits(unixTimeStamp.Value, 10);
-            return new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds((double)unixTimeStamp);
+            return DateTimeOffset.FromUnixTimeSeconds((long)unixTimeStamp).UtcDateTime;
         }
 
         public static DateTime? FromUnixTimeStamp(string unixTimeStamp)
@@ -32,7 +32,7 @@ namespace BookmarksManager
                 return number;
             int numberOfDigits = (int)Math.Floor(Math.Log10(number) + 1);
             if (numberOfDigits >= n)
-                return (int)Math.Truncate((number / Math.Pow(10, numberOfDigits - n)));
+                return (long)Math.Truncate((number / Math.Pow(10, numberOfDigits - n)));
             else
                 return number;
         }

--- a/tests/BookmarksManager.Tests/NetscapeWritterTests.cs
+++ b/tests/BookmarksManager.Tests/NetscapeWritterTests.cs
@@ -135,5 +135,21 @@ namespace BookmarksManager.Tests
                 Assert.IsTrue(content.Contains(Convert.ToBase64String(randomBytes)));
             }
         }
+
+        [TestMethod]
+        public void DateTest()
+        {
+            var bookmarks = Helpers.GetSimpleStructure();
+            var testDate = new DateTime(2039, 01, 01, 12, 12, 12);
+            var unixTimeString = ((DateTimeOffset)testDate).ToUnixTimeSeconds().ToString();
+            bookmarks.Add(new BookmarkLink("http://example.com", "DateTest") {Added = testDate});
+            var writter = new NetscapeBookmarksWriter(bookmarks);
+            using (var stream = new MemoryStream())
+            {
+                writter.Write(stream);
+                var content = writter.OutputEncoding.GetString(stream.ToArray());
+                Assert.IsTrue(content.Contains($"ADD_DATE=\"{unixTimeString}\""));
+            }
+        }
     }
 }


### PR DESCRIPTION
When saving bookmarks, the attribute values for the Datetime are not converted correctly, and the current time is always used, no matter what time is specified.

This PR fixes this problem.