### PR TITLE
Fix dynamic Dispose switch case

### DIFF
--- a/src/BookmarksManager.Firefox/DynamicDataReader.cs
+++ b/src/BookmarksManager.Firefox/DynamicDataReader.cs
@@ -42,7 +42,7 @@ namespace BookmarksManager.Firefox
                 case "Close":
                     _baseReader.Close();
                     break;
-                case "Dispose()":
+                case "Dispose":
                     _baseReader.Dispose();
                     break;
             }


### PR DESCRIPTION
## Summary
- correct the case label used for disposing the underlying reader

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533c751a0c832b9a568befdc4e7c94