### PR TITLE
Add DateTimeHelper millisecond tests

### DIFF
--- a/tests/BookmarksManager.Tests/DateTimeHelperTests.cs
+++ b/tests/BookmarksManager.Tests/DateTimeHelperTests.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BookmarksManager;
+
+namespace BookmarksManager.Tests
+{
+    [TestClass]
+    public class DateTimeHelperTests
+    {
+        [TestMethod]
+        public void Truncates13DigitLongTimestamp()
+        {
+            long timestampMs = 1640995200123;
+            var expected = new DateTime(2022, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var result = DateTimeHelper.FromUnixTimeStamp(timestampMs);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Truncates13DigitStringTimestamp()
+        {
+            string timestampMs = "1640995200123";
+            var expected = new DateTime(2022, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var result = DateTimeHelper.FromUnixTimeStamp(timestampMs);
+            Assert.AreEqual(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test DateTimeHelper conversions

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68533c7130c0832bbd80acad8d9174bc