### PR TITLE
Fix toolbar property name

### DIFF
--- a/src/BookmarksManager.Firefox/FirefoxBookmarkFolder.cs
+++ b/src/BookmarksManager.Firefox/FirefoxBookmarkFolder.cs
@@ -11,9 +11,9 @@
         public string Description { get; set; }
 
         /// <summary>
-        /// Indicates if this folder is displayed in Firefox bookmarks toolbar 
+        /// Indicates if this folder is displayed in Firefox bookmarks toolbar
         /// </summary>
-        public bool IsBoomarksToolbar { get; set; }
+        public bool IsBookmarksToolbar { get; set; }
 
         /// <summary>
         /// Internal Firefox bookmarks type (menu,tags,unfiled,toolbar)

--- a/src/BookmarksManager.Firefox/FirefoxBookmarksReader.cs
+++ b/src/BookmarksManager.Firefox/FirefoxBookmarksReader.cs
@@ -233,7 +233,7 @@ namespace BookmarksManager.Firefox
             };
             if (row.Id == bookmarksToolbarId)
             {
-                folder.IsBoomarksToolbar = true;
+                folder.IsBookmarksToolbar = true;
                 folder.Attributes.Add("personal_toolbar_folder", "true");
             }
             if (row.Attributes != null)


### PR DESCRIPTION
## Summary
- rename Firefox bookmark folder property `IsBookmarksToolbar`
- update row mapping to use new property name

## Testing
- `dotnet build BookmarksManager.sln`
- `dotnet test BookmarksManager.sln` *(fails: missing .NET 3.1 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68533c5fe818832b85d07f7f0fb029ec