### PR TITLE
Fix README writer snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ var bookmarks = new BookmarkFolder()
 {
     new BookmarkLink("http://example.com", "Example")
 };
-var writter = new NetscapeBookmarksWritter(bookmarks);
+var writer = new NetscapeBookmarksWriter(bookmarks);
 
-Console.WriteLine(writter.ToString());
+Console.WriteLine(writer.ToString());
 
-//supports writting to stream with custom encoding
-writter.OutputEncoding = Encoding.GetEncoding(1257);
+//supports writing to stream with custom encoding
+writer.OutputEncoding = Encoding.GetEncoding(1257);
 using (var file = File.OpenWrite("path_to_file"))
 {
-    writter.Write(file);
+    writer.Write(file);
 }
 ```


### PR DESCRIPTION
## Summary
- fix writer class name in README
- fix variable names in README code snippet
- fix typo "writting" -> "writing"
- verify README renders via pandoc

## Testing
- `pandoc README.md -o /tmp/README.html`
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533c698dd4832b92282d7348c8aee4