### PR TITLE
Fix doc for overwriting bookmark files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Console.WriteLine(writer.ToString());
 
 //supports writing to stream with custom encoding
 writer.OutputEncoding = Encoding.GetEncoding(1257);
-using (var file = File.OpenWrite("path_to_file"))
+// Use FileMode.Create to overwrite existing files and avoid leftover content
+using (var file = File.Open("path_to_file", FileMode.Create))
 {
     writer.Write(file);
 }


### PR DESCRIPTION
## Summary
- update usage example in README to open the file with `FileMode.Create`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685340cd1a8c832bb01f1bee30f6fcee