### PR TITLE
Fix typos across project

### DIFF
--- a/src/BookmarksManager.Chrome/ChromeBookmarksReader.cs
+++ b/src/BookmarksManager.Chrome/ChromeBookmarksReader.cs
@@ -9,7 +9,7 @@ namespace BookmarksManager.Chrome
 {
 
     /// <summary>
-    /// Class reponsible for reading Chrome bookmarks
+    /// Class responsible for reading Chrome bookmarks
     /// It accepts JSON from Chrome API (as per https://developer.chrome.com/extensions/bookmarks#type-BookmarkTreeNode)
     /// As well as JSON from Chrome bookmarks file (%AppData%\Local\Google\Chrome\User Data\Default\bookmarks)
     /// </summary>
@@ -47,7 +47,7 @@ namespace BookmarksManager.Chrome
         }
 
         /// <summary>
-        /// Returns true if JSON content is from chrome bookmakrs file
+        /// Returns true if JSON content is from chrome bookmarks file
         /// </summary>
         protected virtual bool IsBookmarksFile(string json)
         {

--- a/src/BookmarksManager.Firefox/FirefoxBookmarkFolder.cs
+++ b/src/BookmarksManager.Firefox/FirefoxBookmarkFolder.cs
@@ -22,7 +22,7 @@
 
         /// <summary>
         /// Indicates if this is internal Firefox bookmark not created by user (i.e. Most visited, History, etc)
-        /// Tags, Unsorted bookmarks, Bookmarks toolbar and Bookmarks meny are not considered internal
+        /// Tags, Unsorted bookmarks, Bookmarks toolbar and Bookmarks menu are not considered internal
         /// </summary>
         public bool Internal { get; set; }
 

--- a/src/BookmarksManager.Firefox/FirefoxBookmarksReader.cs
+++ b/src/BookmarksManager.Firefox/FirefoxBookmarksReader.cs
@@ -50,7 +50,7 @@ namespace BookmarksManager.Firefox
         /// <summary>
         /// Reads from Firefox bookmarks database 
         /// </summary>
-        /// <returns>Boomarks container filled with bookmaks from Firefox db</returns>
+        /// <returns>Bookmarks container filled with bookmarks from Firefox db</returns>
         public virtual FirefoxBookmarkFolder Read()
         {
             using (var connection = new SQLiteConnection(string.Format(ConnectionStringTemplate, FilePath)))

--- a/src/BookmarksManager/ExtensionMethods/TextHelpers.cs
+++ b/src/BookmarksManager/ExtensionMethods/TextHelpers.cs
@@ -37,7 +37,7 @@ namespace BookmarksManager
                 return Encoding.GetEncoding("utf-7");
             }
 
-            //if number of zero bytes exeeds threshold, asume it's utf32 or utf16 content
+            //if number of zero bytes exceeds threshold, assume it's utf32 or utf16 content
             //this does not check for BigEndian
             var zeroBytesCnt = b.Count(x => x == 0);
             if (zeroBytesCnt > b.Length*0.5)

--- a/src/BookmarksManager/NetscapeFormat/HTMLparser.cs
+++ b/src/BookmarksManager/NetscapeFormat/HTMLparser.cs
@@ -828,7 +828,7 @@ namespace Majestic12
 
             EntityReverseLookup = new string[10000];
 
-            // calculate min/max lenght of known entities
+            // calculate min/max length of known entities
             foreach (var sKey in Entities.Keys)
             {
                 if (sKey.Length < MinEntityLen || MinEntityLen == 0)
@@ -1250,7 +1250,7 @@ namespace Majestic12
                         //sText.Append(cChar);
                         // NOTE: this is manual inlining from actual object
 
-                        // NOTE: we go here for speculative insertion that expectes that we won't run out of
+                        // NOTE: we go here for speculative insertion that expects that we won't run out of
                         // buffer, which should be big enough to hold most of HTML data.
                         /*
 							if(sText.iBufPos>=DynaString.TEXT_CAPACITY)
@@ -1401,7 +1401,7 @@ namespace Majestic12
                 }
                 cChar = NextChar();
 
-                // we are definately done
+                // we are definitely done
                 if (cChar == 0)
                     break;
 
@@ -1585,7 +1585,7 @@ namespace Majestic12
 
                 iChars++;
 
-                // we are definately done
+                // we are definitely done
                 if (cChar == 0)
                     break;
 

--- a/tests/BookmarksManager.Chrome.Tests/CombinedReaderWriterTests.cs
+++ b/tests/BookmarksManager.Chrome.Tests/CombinedReaderWriterTests.cs
@@ -15,12 +15,12 @@ namespace BookmarksManager.Chrome.Tests
         public void EmptyContainer()
         {
             var emptyContainer = new BookmarkFolder();
-            var writter = new NetscapeBookmarksWriter(emptyContainer);
+            var writer = new NetscapeBookmarksWriter(emptyContainer);
             var reader = new NetscapeBookmarksReader();
-            var write1 = writter.ToString();
-            var readed = reader.Read(write1);
-            writter = new NetscapeBookmarksWriter(readed);
-            var write2 = writter.ToString();
+            var write1 = writer.ToString();
+            var read = reader.Read(write1);
+            writer = new NetscapeBookmarksWriter(read);
+            var write2 = writer.ToString();
             Assert.AreEqual(write1, write2, true);
         }
 
@@ -32,13 +32,13 @@ namespace BookmarksManager.Chrome.Tests
                 new BookmarkLink("a", "b") {Attributes = new Dictionary<string, string> {{"custom", "1"}}},
                 new BookmarkFolder("folder") {Attributes = new Dictionary<string, string> {{"custom", "2"}, {"add_date", "ę"}}}
             };
-            var writter = new NetscapeBookmarksWriter(container);
+            var writer = new NetscapeBookmarksWriter(container);
             var reader = new NetscapeBookmarksReader();
-            var write1 = writter.ToString();
-            var readed = reader.Read(write1);
-            Assert.AreEqual("1", readed.AllLinks.First().Attributes["custom"]);
-            Assert.AreEqual("2", readed.GetAllItems<BookmarkFolder>().First().Attributes["custom"]);
-            Assert.IsFalse(readed.GetAllItems<BookmarkFolder>().First().Attributes.ContainsKey("add_date"), "add_date is ignored attribute, it must not be written");
+            var write1 = writer.ToString();
+            var read = reader.Read(write1);
+            Assert.AreEqual("1", read.AllLinks.First().Attributes["custom"]);
+            Assert.AreEqual("2", read.GetAllItems<BookmarkFolder>().First().Attributes["custom"]);
+            Assert.IsFalse(read.GetAllItems<BookmarkFolder>().First().Attributes.ContainsKey("add_date"), "add_date is ignored attribute, it must not be written");
         }
 
         [TestMethod]
@@ -46,15 +46,15 @@ namespace BookmarksManager.Chrome.Tests
         {
             var container = Helpers.GetSimpleStructure();
             container.Add(new BookmarkLink("test", "test123") {Description = "<br>"});
-            var writter = new NetscapeBookmarksWriter(container);
+            var writer = new NetscapeBookmarksWriter(container);
             var reader = new NetscapeBookmarksReader();
-            var write1 = writter.ToString();
-            var readed = reader.Read(write1);
-            writter = new NetscapeBookmarksWriter(readed);
-            var write2 = writter.ToString();
-            readed = reader.Read(write2);
+            var write1 = writer.ToString();
+            var read = reader.Read(write1);
+            writer = new NetscapeBookmarksWriter(read);
+            var write2 = writer.ToString();
+            read = reader.Read(write2);
             Assert.AreEqual(write1, write2, true);
-            Assert.IsNotNull(readed.AllLinks.FirstOrDefault(l => l.Title == "test123" && l.Description == "<br>"), "Description must be preserved between reads and writes");
+            Assert.IsNotNull(read.AllLinks.FirstOrDefault(l => l.Title == "test123" && l.Description == "<br>"), "Description must be preserved between reads and writes");
         }
 
 
@@ -64,12 +64,12 @@ namespace BookmarksManager.Chrome.Tests
             var container = Helpers.GetSimpleStructure();
             container.Add(new BookmarkLink("test", "ƒ"));
             var ms = new MemoryStream();
-            var writter = new NetscapeBookmarksWriter(container) { OutputEncoding = Encoding.Unicode };
-            writter.Write(ms);
+            var writer = new NetscapeBookmarksWriter(container) { OutputEncoding = Encoding.Unicode };
+            writer.Write(ms);
             ms = new MemoryStream(ms.GetBuffer());
             var reader = new NetscapeBookmarksReader { AutoDetectEncoding = true };
-            var readed = reader.Read(ms);
-            Assert.AreEqual(container.AllItems.Last().Title, readed.AllItems.Last().Title);
+            var read = reader.Read(ms);
+            Assert.AreEqual(container.AllItems.Last().Title, read.AllItems.Last().Title);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix various spelling mistakes in source comments
- rename `NetscapeWritterTests` to `NetscapeWriterTests`
- update tests to use `writer`/`read` variables

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685343067be8832b9c6bf24af5adcf60